### PR TITLE
#36 handle missed modal id scenario

### DIFF
--- a/src/ModalProvider.test.tsx
+++ b/src/ModalProvider.test.tsx
@@ -11,6 +11,7 @@ import {
   OnExitedEvent,
 } from './test-utils';
 import { Options, ShowFnOutput, State } from './types';
+import { MISSED_MODAL_ID_ERROR_MESSAGE } from './constants';
 
 describe('ModalProvider', () => {
   const rootId = '000';
@@ -29,13 +30,16 @@ describe('ModalProvider', () => {
   };
 
   let uidSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     uidSpy = jest.spyOn(utils, 'uid').mockReturnValueOnce(modalId);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     uidSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   test('happy path scenario (with options)', () => {
@@ -79,6 +83,44 @@ describe('ModalProvider', () => {
     });
 
     expect(result.current.state[id]).toBe(undefined);
+  });
+
+  test('unhappy path (missed ID errors)', () => {
+    const { result } = renderHook(() => React.useContext(ModalContext), {
+      wrapper,
+    });
+
+    act(() => {
+      modal = result.current.showModal(Modal, modalProps);
+    });
+
+    act(() => {
+      result.current.hideModal('');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        MISSED_MODAL_ID_ERROR_MESSAGE
+      );
+    });
+
+    act(() => {
+      result.current.destroyModal('');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        MISSED_MODAL_ID_ERROR_MESSAGE
+      );
+    });
+
+    act(() => {
+      result.current.updateModal('', {});
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        MISSED_MODAL_ID_ERROR_MESSAGE
+      );
+    });
+
+    act(() => {
+      result.current.destroyModalsByRootId('');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        MISSED_MODAL_ID_ERROR_MESSAGE
+      );
+    });
   });
 
   test('happy path scenario (without options)', () => {

--- a/src/ModalProvider.tsx
+++ b/src/ModalProvider.tsx
@@ -8,6 +8,10 @@ import {
   ShowFn,
   UpdateFn,
 } from './types';
+import {
+  MISSED_MODAL_ID_ERROR_MESSAGE,
+  MISSED_MODAL_ROOT_ID_ERROR_MESSAGE,
+} from './constants';
 import { uid } from './utils';
 
 type Props = {
@@ -18,47 +22,71 @@ export default function ModalProvider({ children }: Props) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
   const update = React.useCallback<UpdateFn>(
-    (id, { open, ...props }) =>
+    (id, { open, ...props }) => {
+      if (!id) {
+        console.error(MISSED_MODAL_ID_ERROR_MESSAGE);
+        return;
+      }
+
       dispatch({
         type: Types.UPDATE,
         payload: {
           id,
           props,
         },
-      }),
+      });
+    },
     [dispatch]
   );
 
   const hide = React.useCallback<HideFn>(
-    id =>
+    id => {
+      if (!id) {
+        console.error(MISSED_MODAL_ID_ERROR_MESSAGE);
+        return;
+      }
+
       dispatch({
         type: Types.HIDE,
         payload: {
           id,
         },
-      }),
+      });
+    },
     [dispatch]
   );
 
   const destroy = React.useCallback<DestroyFn>(
-    id =>
+    id => {
+      if (!id) {
+        console.error(MISSED_MODAL_ID_ERROR_MESSAGE);
+        return;
+      }
+
       dispatch({
         type: Types.DESTROY,
         payload: {
           id,
         },
-      }),
+      });
+    },
     [dispatch]
   );
 
   const destroyByRootId = React.useCallback<DestroyByRootIdFn>(
-    rootId =>
+    rootId => {
+      if (!rootId) {
+        console.error(MISSED_MODAL_ROOT_ID_ERROR_MESSAGE);
+        return;
+      }
+
       dispatch({
         type: Types.DESTROY_BY_ROOT_ID,
         payload: {
           rootId,
         },
-      }),
+      });
+    },
     [dispatch]
   );
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const MISSED_MODAL_ID_ERROR_MESSAGE = '[ERROR]: Modal ID is missing';
+export const MISSED_MODAL_ROOT_ID_ERROR_MESSAGE =
+  '[ERROR]: Modal root ID is missing';


### PR DESCRIPTION
Bug fixes that occur if `hideModal`, `updateModal` or `destroyModal` functions are called without provided modal ID in the argument.