### PR TITLE
Allow model rendering to be overridden

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react';
+import { ComponentType, ReactElement } from 'react';
 
 export type ModalComponent<P> = ComponentType<P>;
 
@@ -56,3 +56,13 @@ export type ShowFnOutput<P> = {
   destroy: () => void;
   update: (newProps: Partial<ModalComponentProps<P>>) => void;
 };
+
+export interface RenderModalFnParams {
+  Component: ComponentType<any>;
+  props: Props | undefined;
+  key: string;
+  handleClose: (...args: any[]) => void;
+  handleExited: ((...args: any[]) => void) | undefined;
+}
+
+export type RenderModalFn = (params: RenderModalFnParams) => ReactElement;


### PR DESCRIPTION
This partially fixes #41 by allowing the way ModalProvider renders modals to be overridden.

e.g. A Material UI v5 project should be able to use this to make it compatible until MUI v5 is released and you make a new major for v5.

```ts
ReactDOM.render(
  <ModalProvider
    renderModal={params => {
      const { Component, props, key, handleClose, handleExited } = params;

      return (
        <Component
          {...props}
          key={key}
          onClose={handleClose}
          {...(handleExited && { TransitionProps: { onExited: handleExited } })}
        />
      );
    }}
  >
    <App />
  </ModalProvider>,
  document.getElementById('root')
);
```

Not sure how you want to document this.