### PR TITLE
#86 modal config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.0",
   "license": "MIT",
   "name": "mui-modal-provider",
   "author": "Quernest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export {
 } from './modal-provider';
 export { default as useModal, UseModalOptions } from './use-modal';
 export * from './types';
+export * from './modal-config';

--- a/src/modal-config.ts
+++ b/src/modal-config.ts
@@ -1,0 +1,17 @@
+import { ModalConfig } from './types';
+
+const config: ModalConfig = {
+  /**
+   * If set to `true` you will get an error when trying to access
+   * a context without the `ModalProvider` declared above.
+   */
+  enforceProvider: false,
+};
+
+export function setModalConfig(newConfig: Partial<ModalConfig>) {
+  Object.assign(config, newConfig);
+}
+
+export function getModalConfig() {
+  return config;
+}

--- a/src/modal-context.ts
+++ b/src/modal-context.ts
@@ -17,6 +17,20 @@ export interface ModalContextState {
   showModal: ShowFn;
 }
 
+export const modalContextFallback: ModalContextState = {
+  state: {},
+  updateModal: () => undefined,
+  hideModal: () => undefined,
+  destroyModal: () => undefined,
+  destroyModalsByRootId: () => undefined,
+  showModal: () => ({
+    id: 'id',
+    hide: () => undefined,
+    destroy: () => undefined,
+    update: () => undefined,
+  }),
+};
+
 const ModalContext = createContext<ModalContextState | undefined>(undefined);
 
 export default ModalContext;

--- a/src/modal-provider.test.tsx
+++ b/src/modal-provider.test.tsx
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import * as utils from './utils';
-import useModalContext from './use-modal-context';
 import {
   LegacyModalProviderWrapper as legacyWrapper,
   ModalProviderWrapper as wrapper,
@@ -12,6 +11,7 @@ import Modal, { ModalProps } from './test-utils/modal';
 import LegacyModal from './test-utils/legacy-modal';
 import { Options, ShowFnOutput, State } from './types';
 import { MISSED_MODAL_ID_ERROR_MESSAGE } from './constants';
+import useModal from './use-modal';
 
 describe('ModalProvider', () => {
   const rootId = '000';
@@ -33,7 +33,7 @@ describe('ModalProvider', () => {
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    uidSpy = jest.spyOn(utils, 'uid').mockReturnValueOnce(modalId);
+    uidSpy = jest.spyOn(utils, 'uid').mockReturnValue(modalId);
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -43,7 +43,8 @@ describe('ModalProvider', () => {
   });
 
   test('happy path scenario (with options)', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    uidSpy = jest.spyOn(utils, 'uid').mockReturnValueOnce(rootId);
+    const { result } = renderHook(() => useModal(), {
       wrapper,
     });
 
@@ -86,7 +87,7 @@ describe('ModalProvider', () => {
   });
 
   test('unhappy path (missed ID errors)', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    const { result } = renderHook(() => useModal(), {
       wrapper,
     });
 
@@ -123,8 +124,9 @@ describe('ModalProvider', () => {
     });
   });
 
-  test('happy path scenario (without options)', () => {
-    const { result } = renderHook(() => useModalContext(), {
+  test('happy path scenario (without options provided)', () => {
+    uidSpy = jest.spyOn(utils, 'uid').mockReturnValueOnce(rootId);
+    const { result } = renderHook(() => useModal(), {
       wrapper,
     });
 
@@ -133,8 +135,11 @@ describe('ModalProvider', () => {
     });
 
     const expectedState: State = {
-      [modalId]: {
+      [id]: {
         component: Modal,
+        options: {
+          rootId: rootId,
+        },
         props: {
           open: true,
           ...modalProps,
@@ -146,7 +151,7 @@ describe('ModalProvider', () => {
   });
 
   it('should automaticaly destroy on close', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    const { result } = renderHook(() => useModal(), {
       wrapper,
     });
 
@@ -163,7 +168,7 @@ describe('ModalProvider', () => {
   });
 
   it('should fire onClose prop event on hide', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    const { result } = renderHook(() => useModal(), {
       wrapper,
     });
 
@@ -184,7 +189,7 @@ describe('ModalProvider', () => {
   });
 
   it('should fire TransitionProps.onExited prop event on hide', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    const { result } = renderHook(() => useModal(), {
       wrapper: noSuspenseWrapper,
     });
 
@@ -205,7 +210,7 @@ describe('ModalProvider', () => {
   });
 
   it('should fire onExited prop event on hide', () => {
-    const { result } = renderHook(() => useModalContext(), {
+    const { result } = renderHook(() => useModal(), {
       wrapper: legacyWrapper,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,7 @@ export interface ShowFnOutput<P> {
   destroy: () => void;
   update: (newProps: Partial<ModalComponentProps<P>>) => void;
 }
+
+export interface ModalConfig {
+  enforceProvider: boolean;
+}

--- a/src/use-modal-context.test.tsx
+++ b/src/use-modal-context.test.tsx
@@ -1,3 +1,4 @@
+import { setModalConfig } from './modal-config';
 import { useContext } from 'react';
 import useModalContext from './use-modal-context';
 
@@ -9,9 +10,11 @@ jest.mock('react', () => ({
 describe('useModalContext', () => {
   it('throws an error when not used within ModalProvider', () => {
     (useContext as jest.Mock).mockReturnValue(undefined);
+    setModalConfig({ enforceProvider: true });
     expect(() => useModalContext()).toThrow(
       'useModalContext must be used within a ModalProvider'
     );
+    setModalConfig({ enforceProvider: false });
   });
 
   it('returns the context when used within ModalProvider', () => {

--- a/src/use-modal-context.ts
+++ b/src/use-modal-context.ts
@@ -1,12 +1,14 @@
 import { useContext } from 'react';
-import ModalContext from './modal-context';
+import ModalContext, { modalContextFallback } from './modal-context';
+import { getModalConfig } from './modal-config';
 
 export default function useModalContext() {
   const context = useContext(ModalContext);
+  const { enforceProvider } = getModalConfig();
 
-  if (context === undefined) {
+  if (enforceProvider && context === undefined) {
     throw new Error('useModalContext must be used within a ModalProvider');
   }
 
-  return context;
+  return context || modalContextFallback;
 }

--- a/src/use-modal.ts
+++ b/src/use-modal.ts
@@ -15,18 +15,18 @@ export default function useModal(options: UseModalOptions = defaultOptions) {
   const { disableAutoDestroy } = { ...defaultOptions, ...options };
   const {
     showModal,
-    destroyModalsByRootId: destroy,
-    ...otherContextProps
+    destroyModal,
+    ...otherModalContextProps
   } = useModalContext();
   const id = useRef<string>(uid(6));
 
   useEffect(
     () => () => {
-      if (!disableAutoDestroy) {
-        destroy(id.current);
+      if (!disableAutoDestroy && destroyModal) {
+        destroyModal(id.current);
       }
     },
-    [disableAutoDestroy, destroy]
+    [disableAutoDestroy, destroyModal]
   );
 
   return {
@@ -35,6 +35,7 @@ export default function useModal(options: UseModalOptions = defaultOptions) {
         showModal(component, props, { rootId: id.current, ...options }),
       [showModal]
     ),
-    ...otherContextProps,
+    destroyModal,
+    ...otherModalContextProps,
   };
 }


### PR DESCRIPTION
Usage example:

```ts
import { setModalConfig } from 'mui-modal-provider'

setModalConfig({ enforceProvider: true })

```