### PR TITLE
Fix Fragment warning

### DIFF
--- a/src/modal-provider.tsx
+++ b/src/modal-provider.tsx
@@ -206,7 +206,9 @@ export default function ModalProvider({
       }}
     >
       {children}
-      <SuspenseWrapper fallback={fallback}>{renderState()}</SuspenseWrapper>
+      <SuspenseWrapper {...(suspense && { fallback })}>
+        {renderState()}
+      </SuspenseWrapper>
     </ModalContext.Provider>
   );
 }


### PR DESCRIPTION
Fix for
```
Warning: Invalid prop `fallback` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.
```
When `suspense={false}`